### PR TITLE
Update pom.xml to use 5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Services management web application Maven overlay for CAS with externalized conf
 # Versions
 
 ```xml
-<cas.version>5.0.x</cas.version>
+<cas.version>5.1.x</cas.version>
 ```
 
 # Requirements
@@ -34,10 +34,13 @@ To update `SNAPSHOT` versions run:
 ./build.sh package -U
 ```
 
+## Windows Build
+On Windows you can run build.cmd instead of build.sh. The usage may differ from build.sh, run "build.cmd help" for usage.
+
 ## Note
 
 If you are running the management web application on the same machine as the CAS server web application itself, 
-you will need to eveluate the build script and make sure the configuration files don't override each other.
+you will need to evaluate the build script and make sure the configuration files don't override each other.
 
 
 # Deployment

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     </dependencies>
 
     <properties>
-        <cas.version>5.0.6</cas.version>
+        <cas.version>5.1.0</cas.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Here it is. 

I am having trouble logging in to this using https://jasigcas.herokuapp.com/cas - service ticket validation from management app fails because my outbound traffic goes through an SSL proxy (that issues its own cert that java doesn't trust). I have put the proxy's certs in Java's truststore but is CAS management app not using that? I couldn't see in the code where it used internal truststore.jks file.

Also, you do know that the word "jasig" is part of that heroku deployed cas?